### PR TITLE
Corrige bug do componente InputRadio ao clicar em onChange

### DIFF
--- a/app/src/components/InputRadio/index.js
+++ b/app/src/components/InputRadio/index.js
@@ -25,7 +25,7 @@ export default function InputRadio({
         required={inputRequired}
         value={inputValue}
         checked={inputChecked}
-        onChange={() => inputOnChange(inputId)}
+        onChange={inputOnChange}
       />
       <label htmlFor={labelHtmlFor} className={labelClass}>
         {labelText}


### PR DESCRIPTION
Pequena alteração no componente InputRadio.

De `onChange={() => inputOnChange(inputId)} `para `onChange={inputOnChange}`
